### PR TITLE
included IInvokeHandlerContext as a trigger for the diagnosticsListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Diagnostics package exposes four different events from [behaviors](https://d
  - IIncomingLogicalMessageContext
  - IOutgoingPhysicalMessageContext
  - IOutgoingLogicalMessageContext
+ - IInvokeHandlerContext
  
 The Physical message variants include full Activity support. All diagnostics events pass through the corresponding [context object](https://docs.particular.net/nservicebus/pipeline/steps-stages-connectors) as its event argument.
  

--- a/src/NServiceBus.Extensions.Diagnostics/ActivityNames.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/ActivityNames.cs
@@ -6,5 +6,6 @@
         public const string OutgoingPhysicalMessage = "NServiceBus.Extensions.Diagnostics.OutgoingPhysicalMessage";
         public const string IncomingLogicalMessage = "NServiceBus.Extensions.Diagnostics.IncomingLogicalMessage";
         public const string OutgoingLogicalMessage = "NServiceBus.Extensions.Diagnostics.OutgoingLogicalMessage";
+        public const string InvokedHandler = "NServiceBus.Extensions.Diagnostics.InvokedHandler";
     }
 }

--- a/src/NServiceBus.Extensions.Diagnostics/DiagnosticsFeature.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/DiagnosticsFeature.cs
@@ -16,6 +16,7 @@ namespace NServiceBus.Extensions.Diagnostics
             context.Pipeline.Register(new OutgoingPhysicalMessageDiagnostics(), "Appends W3C trace information to outgoing messages.");
             context.Pipeline.Register(new IncomingLogicalMessageDiagnostics(), "Raises diagnostic events for successfully processed messages.");
             context.Pipeline.Register(new OutgoingLogicalMessageDiagnostics(), "Raises diagnostic events for successfully sent messages.");
+            context.Pipeline.Register(new InvokedHandlerDiagnostics(), "Raises diagnostic events when a handler/saga was invoked.");
         }
     }
 }

--- a/src/NServiceBus.Extensions.Diagnostics/InvokedHandlerDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/InvokedHandlerDiagnostics.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NServiceBus.Pipeline;
+
+namespace NServiceBus.Extensions.Diagnostics
+{
+    public class InvokedHandlerDiagnostics : Behavior<IInvokeHandlerContext>
+    {
+        private readonly DiagnosticListener _diagnosticListener;
+        private const string EventName = ActivityNames.InvokedHandler + ".Processed";
+
+        public InvokedHandlerDiagnostics(DiagnosticListener diagnosticListener)
+        {
+            _diagnosticListener = diagnosticListener;
+        }
+
+        public InvokedHandlerDiagnostics() : this(new DiagnosticListener(ActivityNames.InvokedHandler))
+        {
+        }
+
+        public override async Task Invoke(IInvokeHandlerContext context, Func<Task> next)
+        {
+            await next().ConfigureAwait(false);
+
+            if (_diagnosticListener.IsEnabled(EventName))
+            {
+                _diagnosticListener.Write(EventName, context);
+            }
+        }
+    }
+}

--- a/test/NServiceBus.Extensions.Diagnostics.Tests/InvokedHandlerDiagnosticsTests.cs
+++ b/test/NServiceBus.Extensions.Diagnostics.Tests/InvokedHandlerDiagnosticsTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using NServiceBus.Testing;
+using Shouldly;
+using Xunit;
+
+namespace NServiceBus.Extensions.Diagnostics.Tests
+{
+    public class InvokedHandlerDiagnosticsTests
+    {
+        [Fact]
+        public async Task Should_not_fire_activity_start_stop_when_no_listener_attached()
+        {
+            var diagnosticListener = new DiagnosticListener("DummySource");
+            var context = new TestableInvokeHandlerContext();
+            var processedFired = false;
+
+            diagnosticListener.Subscribe(new CallbackDiagnosticListener(pair =>
+                {
+                    // This should not fire
+                    if (pair.Key == $"{ActivityNames.InvokedHandler}.Processed")
+                    {
+                        processedFired = true;
+                    }
+                }),
+                (s, o, arg3) => false);
+
+            var behavior = new InvokedHandlerDiagnostics(diagnosticListener);
+
+            await behavior.Invoke(context, () => Task.CompletedTask);
+
+            processedFired.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task Should_fire_activity_start_stop_when_listener_attached()
+        {
+            var diagnosticListener = new DiagnosticListener("DummySource");
+            var context = new TestableInvokeHandlerContext();
+            var processedFired = false;
+
+            diagnosticListener.Subscribe(new CallbackDiagnosticListener(pair =>
+            {
+                if (pair.Key == $"{ActivityNames.InvokedHandler}.Processed")
+                {
+                    processedFired = true;
+                }
+            }));
+
+            var behavior = new InvokedHandlerDiagnostics(diagnosticListener);
+
+            await behavior.Invoke(context, () => Task.CompletedTask);
+
+            processedFired.ShouldBeTrue();
+        }
+        
+    }
+}


### PR DESCRIPTION
Hi,

When working in the context of a saga. It would be nice to validate when the saga actually is marked as completed.

So to create a trigger when the saga is marked as completed in your other repository : [NServiceBus.Extensions.IntegrationTesting](https://github.com/jbogard/NServiceBus.Extensions.IntegrationTesting). I first need an update of this repository, so I can add that functionality in the other repository.

With regards
Timmy