### PR TITLE
Allow end user to add custom enrichment

### DIFF
--- a/src/NServiceBus.Extensions.Diagnostics/InstrumentationOptions.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/InstrumentationOptions.cs
@@ -1,7 +1,15 @@
-﻿namespace NServiceBus.Extensions.Diagnostics
+﻿using System;
+using System.Diagnostics;
+using NServiceBus.Pipeline;
+
+namespace NServiceBus.Extensions.Diagnostics
 {
     public class InstrumentationOptions
     {
         public bool CaptureMessageBody { get; set; }
+
+        public Action<Activity, IIncomingPhysicalMessageContext>? EnrichIncoming { get; set; }
+
+        public Action<Activity, IOutgoingPhysicalMessageContext>? EnrichOutgoing { get; set; }
     }
 }

--- a/src/NServiceBus.Extensions.Diagnostics/InstrumentationOptions.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/InstrumentationOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using NServiceBus.Pipeline;
 
 namespace NServiceBus.Extensions.Diagnostics
 {
@@ -8,8 +8,6 @@ namespace NServiceBus.Extensions.Diagnostics
     {
         public bool CaptureMessageBody { get; set; }
 
-        public Action<Activity, IIncomingPhysicalMessageContext>? EnrichIncoming { get; set; }
-
-        public Action<Activity, IOutgoingPhysicalMessageContext>? EnrichOutgoing { get; set; }
+        public Action<Activity, IReadOnlyDictionary<string, string>>? Enrich { get; set; }
     }
 }

--- a/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
@@ -34,10 +34,12 @@ namespace NServiceBus.Extensions.Diagnostics
 
             Enrich(activity, context.MessageHeaders);
 
-            if (activity.IsAllDataRequested && _options.CaptureMessageBody)
+            if (!activity.IsAllDataRequested) return;
+            if (_options.CaptureMessageBody)
             {
                 activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Message.Body));
             }
+            _options.EnrichIncoming?.Invoke(activity, context);
         }
 
         public void Enrich(Activity activity, IOutgoingPhysicalMessageContext context)
@@ -64,10 +66,12 @@ namespace NServiceBus.Extensions.Diagnostics
 
             Enrich(activity, context.Headers);
 
-            if (activity.IsAllDataRequested && _options.CaptureMessageBody)
+            if (!activity.IsAllDataRequested) return;
+            if (_options.CaptureMessageBody)
             {
-                activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
+	            activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
             }
+            _options.EnrichOutgoing?.Invoke(activity, context);
         }
 
         private void Enrich(Activity activity, IReadOnlyDictionary<string, string> contextHeaders)

--- a/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
@@ -44,7 +44,7 @@ namespace NServiceBus.Extensions.Diagnostics
                 activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Message.Body));
             }
 
-            _options.EnrichIncoming?.Invoke(activity, context);
+            _options.Enrich?.Invoke(activity, context.MessageHeaders);
         }
 
         public void Enrich(Activity activity, IOutgoingPhysicalMessageContext context)
@@ -81,7 +81,7 @@ namespace NServiceBus.Extensions.Diagnostics
                 activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
             }
 
-            _options.EnrichOutgoing?.Invoke(activity, context);
+            _options.Enrich?.Invoke(activity, context.Headers);
         }
 
         private void Enrich(Activity activity, IReadOnlyDictionary<string, string> contextHeaders)

--- a/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
@@ -69,7 +69,7 @@ namespace NServiceBus.Extensions.Diagnostics
             if (!activity.IsAllDataRequested) return;
             if (_options.CaptureMessageBody)
             {
-	            activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
+                activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
             }
             _options.EnrichOutgoing?.Invoke(activity, context);
         }

--- a/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/SettingsActivityEnricher.cs
@@ -34,11 +34,16 @@ namespace NServiceBus.Extensions.Diagnostics
 
             Enrich(activity, context.MessageHeaders);
 
-            if (!activity.IsAllDataRequested) return;
+            if (!activity.IsAllDataRequested)
+            {
+	            return;
+            }
+
             if (_options.CaptureMessageBody)
             {
                 activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Message.Body));
             }
+
             _options.EnrichIncoming?.Invoke(activity, context);
         }
 
@@ -66,11 +71,16 @@ namespace NServiceBus.Extensions.Diagnostics
 
             Enrich(activity, context.Headers);
 
-            if (!activity.IsAllDataRequested) return;
+            if (!activity.IsAllDataRequested)
+            {
+	            return;
+            }
+
             if (_options.CaptureMessageBody)
             {
                 activity.AddTag("messaging.message_payload", Encoding.UTF8.GetString(context.Body));
             }
+
             _options.EnrichOutgoing?.Invoke(activity, context);
         }
 


### PR DESCRIPTION
@jbogard end users should be able to customize the activity enrichment from custom headers they have plugged into their pipelines.  I went for the simplest possible solution which makes the headers & the activity available to be tagged.  Not sure if you want to delineate between incoming & outgoing in the action but I'm open to discussion/thoughts.