### PR TITLE
Preserve baggage order

### DIFF
--- a/src/NServiceBus.Extensions.Diagnostics/IncomingPhysicalMessageDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/IncomingPhysicalMessageDiagnostics.cs
@@ -82,8 +82,10 @@ namespace NServiceBus.Extensions.Diagnostics
 
             _activityEnricher.Enrich(activity, context);
 
-            foreach (var baggageItem in baggageItems)
+            // Iterate backwards to preserve order because Activity baggage is LIFO
+            for (var i = baggageItems.Count - 1; i >= 0; i--)
             {
+                var baggageItem = baggageItems[i];
                 activity.AddBaggage(baggageItem.Key, baggageItem.Value);
             }
 


### PR DESCRIPTION
Preserves the order of baggage when being populated from the incoming message header. Enumerates the baggage list in reverse because the `Activity.AddBaggage(string, string?)` method adds to the front of the list.

Resolves #10 