### PR TITLE
Move Activity Start from IOutgoingLogicalMessageContext to IOutgoingPhysicalMessageContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The Diagnostics package exposes four different events from [behaviors](https://d
 
  - IIncomingPhysicalMessageContext
  - IIncomingLogicalMessageContext
- - IOutgoingPhysicalMessageContext
- - IOutgoingLogicalMessageContext
  - IInvokeHandlerContext
+ - IOutgoingLogicalMessageContext
+ - IOutgoingPhysicalMessageContext
  
 The Physical message variants include full Activity support. All diagnostics events pass through the corresponding [context object](https://docs.particular.net/nservicebus/pipeline/steps-stages-connectors) as its event argument.
  

--- a/src/NServiceBus.Extensions.Diagnostics/OutgoingLogicalMessageDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/OutgoingLogicalMessageDiagnostics.cs
@@ -18,12 +18,21 @@ namespace NServiceBus.Extensions.Diagnostics
 
         public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
         {
-            await next().ConfigureAwait(false);
-
-            if (_diagnosticListener.IsEnabled(EventName))
+            using (StartActivity())
             {
-                _diagnosticListener.Write(EventName, context);
+                await next().ConfigureAwait(false);
+
+                if (_diagnosticListener.IsEnabled(EventName))
+                {
+                    _diagnosticListener.Write(EventName, context);
+                }
             }
+        }
+
+        private static Activity? StartActivity()
+        {
+            var activity = NServiceBusActivitySource.ActivitySource.StartActivity(ActivityNames.OutgoingLogicalMessage, ActivityKind.Producer);
+            return activity;
         }
     }
 }

--- a/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingMessagePipelineTests.cs
+++ b/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingMessagePipelineTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NServiceBus.Pipeline;
+using NServiceBus.Testing;
+using Shouldly;
+using Xunit;
+
+namespace NServiceBus.Extensions.Diagnostics.Tests
+{
+    public class OutgoingMessagePipelineTests
+    {
+        [Fact]
+        public async void Should_custom_enrich_outgoing_activity()
+        {
+            Activity started = null;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "NServiceBus.Extensions.Diagnostics",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity => started = activity
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var logicalContext = new TestableOutgoingLogicalMessageContext();
+            var physicalContext = new TestableOutgoingPhysicalMessageContext();
+
+            var enricher = new TestEnricher((activity, _) => activity.AddTag("Key1", "Value1"));
+
+            var logicalBehavior = new OutgoingLogicalMessageDiagnostics();
+            var customEnrichingBehavior = new DelegateBehavior<IOutgoingPhysicalMessageContext>(async (_, next) =>
+            {
+                var activity = Activity.Current;
+                activity.ShouldNotBeNull("Cannot enrich a null Activity");
+                activity.AddTag("Key2", "Value2");
+                await next();
+            });
+            var physicalBehavior = new OutgoingPhysicalMessageDiagnostics(enricher);
+
+            // Simulates NServiceBus outgoing message pipeline.
+            // The order of the outgoing pipeline is IOutgoingLogicalMessageContext and then IOutgoingPhysicalMessageContext:
+            // https://docs.particular.net/nservicebus/pipeline/steps-stages-connectors#stages-outgoing-pipeline-stages.
+            // Implementations of IMutateOutgoingTransportMessages are executed in the pipeline
+            // after OutgoingLogicalMessageDiagnostics and before OutgoingPhysicalMessageDiagnostics.
+            await logicalBehavior.Invoke(logicalContext,
+                () => customEnrichingBehavior.Invoke(physicalContext,
+                    () => physicalBehavior.Invoke(physicalContext, () => Task.CompletedTask)));
+
+            started.ShouldNotBeNull();
+            started.Tags.ShouldContain(kv => kv.Key == "Key1");
+            started.Tags.ShouldContain(kv => kv.Key == "Key2");
+        }
+
+        private class DelegateBehavior<TContext> : Behavior<TContext>
+            where TContext : class, IBehaviorContext
+        {
+            private readonly Func<TContext, Func<Task>, Task> _invocation;
+
+            public DelegateBehavior(Func<TContext, Func<Task>, Task> invocation)
+            {
+                _invocation = invocation;
+            }
+
+            public override Task Invoke(TContext context, Func<Task> next)
+            {
+                return _invocation(context, next);
+            }
+        }
+
+        private class TestEnricher : IActivityEnricher
+        {
+            private readonly Action<Activity, IOutgoingPhysicalMessageContext> _outgoingEnrichment;
+
+            public TestEnricher(Action<Activity, IOutgoingPhysicalMessageContext> outgoingEnrichment)
+            {
+                _outgoingEnrichment = outgoingEnrichment;
+            }
+
+            public void Enrich(Activity activity, IIncomingPhysicalMessageContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Enrich(Activity activity, IOutgoingPhysicalMessageContext context)
+            {
+                _outgoingEnrichment(activity, context);
+            }
+        }
+    }
+}

--- a/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingPhysicalMessageDiagnosticsTests.cs
+++ b/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingPhysicalMessageDiagnosticsTests.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
-using NServiceBus.Pipeline;
 using NServiceBus.Testing;
 using Shouldly;
 using Xunit;
@@ -19,92 +17,52 @@ namespace NServiceBus.Extensions.Diagnostics.Tests
         [Fact]
         public async Task Should_not_fire_activity_start_stop_when_no_listener_attached()
         {
+            var diagnosticListener = new DiagnosticListener("DummySource");
             var context = new TestableOutgoingPhysicalMessageContext();
-            var stopFired = false;
-            var startFired = false;
+            var processedFired = false;
 
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = source => source.Name == "Nonsense",
-                ActivityStarted = _ => startFired = true,
-                ActivityStopped = _ => stopFired = true
-            };
-            ActivitySource.AddActivityListener(listener);
+            diagnosticListener.Subscribe(new CallbackDiagnosticListener(pair =>
+                {
+                    // This should not fire
+                    if (pair.Key == $"{ActivityNames.OutgoingPhysicalMessage}.Sent")
+                    {
+                        processedFired = true;
+                    }
+                }),
+                (_, _, _) => false);
 
-            var behavior = new OutgoingPhysicalMessageDiagnostics(new FakeActivityEnricher());
+            var behavior = new OutgoingPhysicalMessageDiagnostics(diagnosticListener, new FakeActivityEnricher());
 
             await behavior.Invoke(context, () => Task.CompletedTask);
 
-            startFired.ShouldBeFalse();
-            stopFired.ShouldBeFalse();
+            processedFired.ShouldBeFalse();
         }
 
         [Fact]
         public async Task Should_fire_activity_start_stop_when_listener_attached()
         {
+            var diagnosticListener = new DiagnosticListener("DummySource");
             var context = new TestableOutgoingPhysicalMessageContext();
-            var stopFired = false;
-            var startFired = false;
+            var processedFired = false;
 
-            using var listener = new ActivityListener
+            diagnosticListener.Subscribe(new CallbackDiagnosticListener(pair =>
             {
-                ShouldListenTo = source => source.Name == "NServiceBus.Extensions.Diagnostics",
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStarted = _ => startFired = true,
-                ActivityStopped = _ => stopFired = true
-            };
-            ActivitySource.AddActivityListener(listener);
-
-            var behavior = new OutgoingPhysicalMessageDiagnostics(new FakeActivityEnricher());
-
-            await behavior.Invoke(context, () => Task.CompletedTask);
-
-            startFired.ShouldBeTrue();
-            stopFired.ShouldBeTrue();
-        }
-
-        [Fact]
-        public async Task Should_start_and_log_activity()
-        {
-            var startCalled = false;
-
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = source => source.Name == "NServiceBus.Extensions.Diagnostics",
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStarted = activity =>
+                if (pair.Key == $"{ActivityNames.OutgoingPhysicalMessage}.Sent")
                 {
-                    startCalled = true;
-                    activity.ShouldNotBeNull();
-                    activity.OperationName.ShouldBe(ActivityNames.OutgoingPhysicalMessage);
-                },
-            };
-            ActivitySource.AddActivityListener(listener);
+                    processedFired = true;
+                }
+            }));
 
-            var context = new TestableOutgoingPhysicalMessageContext();
-
-            var behavior = new OutgoingPhysicalMessageDiagnostics(new FakeActivityEnricher());
+            var behavior = new OutgoingPhysicalMessageDiagnostics(diagnosticListener, new FakeActivityEnricher());
 
             await behavior.Invoke(context, () => Task.CompletedTask);
 
-            startCalled.ShouldBeTrue();
+            processedFired.ShouldBeTrue();
         }
 
         [Fact]
-        public async Task Should_start_activity_and_set_appropriate_headers()
+        public async Task Should_set_appropriate_headers()
         {
-            // Generate an id we can use for the request id header (in the correct format)
-
-            Activity started = null;
-
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = source => source.Name == "NServiceBus.Extensions.Diagnostics",
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStarted = activity => started = activity,
-            };
-            ActivitySource.AddActivityListener(listener);
-
             var context = new TestableOutgoingPhysicalMessageContext();
 
             var behavior = new OutgoingPhysicalMessageDiagnostics(new FakeActivityEnricher());
@@ -121,10 +79,7 @@ namespace NServiceBus.Extensions.Diagnostics.Tests
 
             outerActivity.Stop();
 
-            started.ShouldNotBeNull();
-            started.ParentId.ShouldBe(outerActivity.Id);
-
-            context.Headers.ShouldContain(kvp => kvp.Key == "traceparent" && kvp.Value == started.Id);
+            context.Headers.ShouldContain(kvp => kvp.Key == "traceparent" && kvp.Value == outerActivity.Id);
             context.Headers.ShouldContain(kvp => kvp.Key == "tracestate" && kvp.Value == outerActivity.TraceStateString);
             context.Headers.ShouldContain(kvp => kvp.Key == "Correlation-Context" && kvp.Value == "Key2=Value2,Key1=Value1");
             context.Headers.ShouldContain(kvp => kvp.Key == "baggage" && kvp.Value == "Key2=Value2,Key1=Value1");


### PR DESCRIPTION
Move the outgoing message activity start in the message pipeline from from `IOutgoingLogicalMessageContext` to `IOutgoingPhysicalMessageContext`. This change allows the `Activity` object to encompass a larger scope and allows it to be enriched from an implementation of `IMutateOutgoingTransportMessages` (resolves #9).