### PR TITLE
WIP: Fix header propagation

### DIFF
--- a/src/NServiceBus.Extensions.Diagnostics/IncomingPhysicalMessageDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/IncomingPhysicalMessageDiagnostics.cs
@@ -83,6 +83,13 @@ namespace NServiceBus.Extensions.Diagnostics
                 ? NServiceBusActivitySource.ActivitySource.StartActivity(ActivityNames.IncomingPhysicalMessage, ActivityKind.Consumer)
                 : NServiceBusActivitySource.ActivitySource.StartActivity(ActivityNames.IncomingPhysicalMessage, ActivityKind.Consumer, parentId);
 
+            if (activity == null && ActivityContext.TryParse(parentId, traceStateString, out var activityContext))
+            {
+                activity = new Activity(ActivityNames.IncomingPhysicalMessage);
+                activity.SetParentId(activityContext.TraceId, activityContext.SpanId, activityContext.TraceFlags);
+                activity.Start();
+            }
+
             if (activity == null)
             {
                 return activity;

--- a/src/NServiceBus.Extensions.Diagnostics/OutgoingLogicalMessageDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/OutgoingLogicalMessageDiagnostics.cs
@@ -41,7 +41,18 @@ namespace NServiceBus.Extensions.Diagnostics
 
         private static Activity? StartActivity()
         {
-            var activity = NServiceBusActivitySource.ActivitySource.StartActivity(ActivityNames.OutgoingLogicalMessage, ActivityKind.Producer);
+            Activity? activity = null;
+            if (NServiceBusActivitySource.ActivitySource.HasListeners())
+            {
+                activity = NServiceBusActivitySource.ActivitySource.CreateActivity(ActivityNames.OutgoingLogicalMessage, ActivityKind.Client);
+            }
+
+            if (activity is null && Activity.Current is not null)
+            {
+                activity = new Activity(ActivityNames.OutgoingLogicalMessage);
+            }
+
+            activity?.Start();
             return activity;
         }
     }

--- a/src/NServiceBus.Extensions.Diagnostics/OutgoingPhysicalMessageDiagnostics.cs
+++ b/src/NServiceBus.Extensions.Diagnostics/OutgoingPhysicalMessageDiagnostics.cs
@@ -26,14 +26,10 @@ namespace NServiceBus.Extensions.Diagnostics
 
         public override async Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
         {
-            var activity = context.Extensions.TryGet<ICurrentActivity>(out var currentActivity) 
-                ? currentActivity.Current 
-                : Activity.Current;
-
-            if (activity != null)
+            if (context.Extensions.TryGet<ICurrentActivity>(out var currentActivity) && currentActivity?.Current != null)
             {
-                _activityEnricher.Enrich(activity, context);
-                InjectHeaders(activity, context);
+                _activityEnricher.Enrich(currentActivity.Current, context);
+                InjectHeaders(currentActivity.Current, context);
             }
 
             await next().ConfigureAwait(false);

--- a/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingPhysicalMessageDiagnosticsTests.cs
+++ b/test/NServiceBus.Extensions.Diagnostics.Tests/OutgoingPhysicalMessageDiagnosticsTests.cs
@@ -73,6 +73,7 @@ namespace NServiceBus.Extensions.Diagnostics.Tests
             };
             outerActivity.AddBaggage("Key1", "Value1");
             outerActivity.AddBaggage("Key2", "Value2");
+            context.Extensions.Set<ICurrentActivity>(new CurrentContextActivity(outerActivity));
             outerActivity.Start();
 
             await behavior.Invoke(context, () => Task.CompletedTask);


### PR DESCRIPTION
This PR aims to address the issues in #18.

I'm confident in the changes made in the outgoing behaviors and I have verified that an activity with correct `TraceId` and `SpanId` is created when the code enters the new if block in `IncomingPhysicalMessageDiagnostics`.

However, I have not tried the flow with [listeners registered to the ActivitySource](https://github.com/jbogard/NServiceBus.Extensions.Diagnostics/blob/master/src/NServiceBus.Extensions.Diagnostics/IncomingPhysicalMessageDiagnostics.cs#L82-L84). But as this code is untouched, I assume it works as expected. Perhaps there is a way to restructure the control flow?

I note that two unit tests are failing. This is due to https://github.com/jbogard/NServiceBus.Extensions.Diagnostics/commit/85bdb7f2662935a18e21af677fd8c4a656378d09 and the fact that the test relied on `Activity.Current`, not the activity passed in the message context. I fixed one test, and be happy to amend it to the previous commit. However, want your input on how to fix the other test. In this case the `ICurrentActivity` is set on `IOutgoingLogicalMessageContext`. but the test creates a new `IOutgoingPhysicalMessageContext` that does not contain that activity.